### PR TITLE
Unrolled the driver interface changes

### DIFF
--- a/c/src/include/mdv_average16.h
+++ b/c/src/include/mdv_average16.h
@@ -51,6 +51,7 @@
 **
 \******************************************************************************/
 
+/// Invalid pointer (pointer value is null).
 #define MDV_AVERAGE_ERROR_INVALID_POINTER -1
 
 /******************************************************************************\
@@ -152,6 +153,7 @@ mdv_average16_reset(
 **  returns 0.
 **
 **  @param[in] average A pointer to an average structure where to put a sample.
+**  @param[in] sample The sample value to put.
 **
 **  @return The current average value.
 */

--- a/c/src/include/mdv_sensor_api.h
+++ b/c/src/include/mdv_sensor_api.h
@@ -595,7 +595,7 @@ mdv_sensor_set_output_data(
 /*-------------------------------------------------------------------------*//**
 **  @brief Initializes a sensor driver.
 **
-**  @param[in] driver Sensor driver to be initialized.
+**  @param[in] sensor Sensor to be initialized.
 **  @param[in] sensor Type of the sensor to be associated with the driver.
 **  @param[in] funcInit Driver function pointer (mandatory).
 **  @param[in] funcSetCalibrationParams Driver function pointer (optional, set
@@ -674,7 +674,7 @@ mdv_sensor_init(
 /*-------------------------------------------------------------------------*//**
 **  @brief Gets a handle to a sensor.
 **
-**  @param[in] sensor A sensor driver.
+**  @param[in] sensor A sensor.
 **  @param[out] handle Pointer to a sensor handle variable.
 **
 **  @retval MDV_RESULT_OK Handle successfully got.

--- a/c/src/include/mdv_serialport.h
+++ b/c/src/include/mdv_serialport.h
@@ -356,7 +356,7 @@ typedef
 MdvResult_t
 (*MdvSerialPortDriverInterface_Init_t)(
         void
-        );
+);
 
 /*-------------------------------------------------------------------------*//**
 **  @brief Opens the serial port driver.
@@ -374,7 +374,7 @@ typedef
 MdvResult_t
 (*MdvSerialPortDriverInterface_Open_t)(
         MdvSerialPortConfig_t *cfg
-        );
+);
 
 /*-------------------------------------------------------------------------*//**
 **  @brief Closes the serial port.
@@ -389,7 +389,7 @@ typedef
 MdvResult_t
 (*MdvSerialPortDriverInterface_Close_t)(
         void
-        );
+);
 
 /*-------------------------------------------------------------------------*//**
 **  @brief Transfers data to/from the serial port.
@@ -404,7 +404,7 @@ typedef
 MdvResult_t
 (*MdvSerialPortDriverInterface_Transfer_t)(
         MdvSerialPortTransfer_t *tfer
-        );
+);
 
 /*-------------------------------------------------------------------------*//**
 **  @brief Runs the driver.
@@ -421,7 +421,7 @@ MdvResult_t
 (*MdvSerialPortDriverInterface_Run_t)(
         MdvSerialPortTransfer_t *rxd,
         MdvSerialPortTransfer_t *txd
-        );
+);
 
 /******************************************************************************\
 **
@@ -468,7 +468,7 @@ extern "C"{
 typedef struct
 MdvSerialPort_t{
         /// Driver interface.
-        MdvSerialPortDriverInterface_t *drv;
+        MdvSerialPortDriverInterface_t drv;
         /// Port initialization status.
         bool init;
         /// Serial port configuration data.
@@ -499,7 +499,7 @@ extern const MdvSerialPortConfig_t MdvSerialportDefaultConfig;
 /*-------------------------------------------------------------------------*//**
 **  @brief Sets up the driver interface.
 **
-**  @param[out] iface Driver interfae to set up.
+**  @param[out] port Seria port instance which driver interface to set up.
 **  @param[in] funcInit (Mandatory) A function to initialize the port hardware.
 **  @param[in] funcOpen (Mandatory) A function to open the port.
 **  @param[in] funcClose (Mandatory) A function to close the port.
@@ -516,7 +516,7 @@ extern const MdvSerialPortConfig_t MdvSerialportDefaultConfig;
 */
 MdvResult_t
 mdv_serialport_setup_driver_interface(
-        MdvSerialPortDriverInterface_t *iface,
+        MdvSerialPort_t *port,
         MdvSerialPortDriverInterface_Init_t funcInit,
         MdvSerialPortDriverInterface_Open_t funcOpen,
         MdvSerialPortDriverInterface_Close_t funcClose,
@@ -528,8 +528,7 @@ mdv_serialport_setup_driver_interface(
 /*-------------------------------------------------------------------------*//**
 **  @brief Initializes a serial port driver.
 **
-**  @param[out] port Serial port driver to initialize.
-**  @param[in] driver Driver to be associated with the port.
+**  @param[out] port Serial port to initialize.
 **  @param[in] rxCompleted RX completed callback for asynchronous read
 **      operations. Set to null for synchronous reads.
 **  @param[in] txCompleted TX completed callback for asynchronous write
@@ -543,13 +542,13 @@ mdv_serialport_setup_driver_interface(
 **  @return On a driver error returns a negative error code. See the driver 
 **      implementation for more information.
 **
-**  Initializes the serial port and the hardware by invoking driver's 
-**  initialization method.
+**  Initializes the serial port and the hardware by calling driver's 
+**  initialization method. The driver interface must be initialized before this
+**  operation.
 */
 MdvResult_t
 mdv_serialport_init(
         MdvSerialPort_t *port,
-        MdvSerialPortDriverInterface_t *driver,
         MdvSerialPortTransferCompletedCallback_t rxCompleted,
         MdvSerialPortTransferCompletedCallback_t txCompleted,
         MdvTimerSystem_t *timerSys,

--- a/c/src/include/mdv_spi.h
+++ b/c/src/include/mdv_spi.h
@@ -160,7 +160,6 @@ typedef void
         void *userData
 );
 
-
 /******************************************************************************\
 **
 **  DRIVER INTERFACE FUNCTION TYPES
@@ -306,7 +305,7 @@ extern "C"{
 typedef struct
 MdvSpi_t{
         /// Pointer to a SPI driver interface.
-        MdvSpiDriverInterface_t *drv;
+        MdvSpiDriverInterface_t drv;
         /// Stores the port configuration.
         MdvSpiConfig_t cfg;
         /// Transfer completion callback.
@@ -324,7 +323,7 @@ MdvSpi_t{
 /*-------------------------------------------------------------------------*//**
 **  @brief Sets up the driver interface.
 **
-**  @param[out] iface Driver interface to set up.
+**  @param[out] spi SPI port which driver interface to set up.
 **  @param[in] funcInit (Mandatory) A function to initialize the port hardware.
 **  @param[in] funcOpen (Mandatory) A function to open the port.
 **  @param[in] funcClose (Mandatory) A function to close the port.
@@ -341,7 +340,7 @@ MdvSpi_t{
 */
 MdvResult_t
 mdv_spi_setup_driver_interface(
-        MdvSpiDriverInterface_t *iface,
+        MdvSpi_t *spi,
         MdvSpiDriverInterface_Init_t funcInit,
         MdvSpiDriverInterface_Open_t funcOpen,
         MdvSpiDriverInterface_Close_t funcClose,
@@ -354,7 +353,6 @@ mdv_spi_setup_driver_interface(
 **  @brief Opens a SPI port.
 **
 **  @param[in] spi SPI port to open.
-**  @param[in] drv SPI driver interface.
 **  @param[in] config SPI port configuration.
 **  @param[in] callback Callback for asynchronous transfer completed events.
 **      This parameter is optional and can be set to null.
@@ -372,7 +370,6 @@ mdv_spi_setup_driver_interface(
 MdvResult_t
 mdv_spi_open(
         MdvSpi_t *spi,
-        MdvSpiDriverInterface_t *drv,
         MdvSpiConfig_t *config,
         MdvSpiTransferCompletedCallback_t callback,
         void *userData,

--- a/c/src/include/mdv_types.h
+++ b/c/src/include/mdv_types.h
@@ -1,11 +1,11 @@
 /***************************************************************************//**
 **
-**  @defgroup   utils Utility library
+**  @defgroup   madivaru-lib Madivaru library.
 **
-**  General purpose utilities.
+**  General purpose APIs, driver interfaces and utilities.
 **
-**  @file       types.h
-**  @ingroup    utils
+**  @file       mdv_types.h
+**  @ingroup    madivaru-lib
 **  @brief      Common types and macros
 **  @copyright  Copyright (C) 2012-2018 Tuomas Terho. All rights reserved.
 **
@@ -97,7 +97,10 @@ MdvVarType_t{
 */
 typedef struct 
 MdvVar_t{
+        /// Type of the variable.
         MdvVarType_t type;
+        /// Size of a variable array (when a pointer-type variable points to an 
+        /// array).
         uint16_t sz;
         union{
 #ifdef USE_64BIT_VAR_T
@@ -225,7 +228,7 @@ typedef int16_t MdvResult_t;
 **  @brief Tests the minimum boundary of the value.
 **
 **  @param[in] VALUE The value being tested.
-**  @param[in] MAX The minimum possible value.
+**  @param[in] MIN The minimum possible value.
 **
 **  This macro performs a boolean test for the value and the minimum value.
 */

--- a/c/src/utils/mdv_crc32.c
+++ b/c/src/utils/mdv_crc32.c
@@ -1,7 +1,7 @@
 /***************************************************************************//**
 **
-**  @file       crc32.c
-**  @ingroup    utils
+**  @file       mdv_crc32.c
+**  @ingroup    madivaru-lib
 **  @brief      CRC-32 checksum calculator
 **  @copyright  Copyright (C) 2012-2018 Tuomas Terho. All rights reserved.
 **


### PR DESCRIPTION
- Unrolled the driver interface changes where the driver interface was associated as a pointer with the parent structure.